### PR TITLE
Handle flat and nested dependency tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 node_modules
 coverage
+npm-debug.log

--- a/index.js
+++ b/index.js
@@ -2,16 +2,11 @@ var path = require('path');
 var fs = require('fs');
 var findParentDir = require('find-parent-dir');
 
-/**
- * Resolves the url in the top level node_module directory
- * @param {String} targetUrl url to resolve
- * @param {String} source file or directory which is the base point resolving targetUrl
- */
 function resolve(targetUrl, source) {
   var packageRoot = findParentDir.sync(source, 'node_modules');
 
   if (!packageRoot) {
-    return null; // file could not be resolved as npm package
+    return null;
   }
 
   var filePath = path.resolve(packageRoot, 'node_modules', targetUrl);
@@ -26,5 +21,5 @@ module.exports = function importer (url, prev, done) {
     url = resolve(url.substr(1), prev);
   }
 
-  return url && { file: url };
+  return { file: url };
 };

--- a/index.js
+++ b/index.js
@@ -1,10 +1,32 @@
 var path = require('path');
+var fs = require('fs');
 var findParentDir = require('find-parent-dir');
+
+/**
+ * Resolves the url in the nearest node_module directory
+ * @param {String} targetUrl url to resolve
+ * @param {String} sourceFile file which is referring to the targetUrl
+ * @returns file path or false if the file does not exist
+ */
+function resolveDeep(targetUrl, sourceFile) {
+  var packageRoot = findParentDir.sync(sourceFile, 'node_modules') || __dirname;
+  var filePath = path.resolve(packageRoot, 'node_modules', targetUrl);
+
+  return fs.existsSync(path.dirname(filePath)) && filePath;
+}
+
+/**
+ * Resolves the url in the top level node_module directory
+ * @param {String} targetUrl url to resolve
+ */
+function resolveFlat(targetUrl) {
+  return path.resolve('node_modules', targetUrl);
+}
 
 module.exports = function importer (url, prev, done) {
   if (url[ 0 ] === '~') {
-    var packageRoot = findParentDir.sync(prev, 'node_modules') || __dirname;
-    url = path.resolve(packageRoot, 'node_modules', url.substr(1));
+    var targetUrl = url.substr(1);
+    url = resolveDeep(targetUrl, prev) || resolveFlat(targetUrl);
   }
 
   return { file: url };

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var findParentDir = require('find-parent-dir');
  * @returns file path or false if the file does not exist
  */
 function resolveDeep(targetUrl, sourceFile) {
-  var packageRoot = findParentDir.sync(sourceFile, 'node_modules') || __dirname;
+  var packageRoot = findParentDir.sync(sourceFile, 'node_modules');
   var filePath = path.resolve(packageRoot, 'node_modules', targetUrl);
 
   return fs.existsSync(path.dirname(filePath)) && filePath;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-sass-tilde-importer",
-  "version": "0.0.5",
+  "version": "0.0.4",
   "description": "A node-sass custom importer which turns ~ into absolute paths to the nearest parent node_modules directory.",
   "repository": "matthewdavidson/node-sass-tilde-importer",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-sass-tilde-importer",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A node-sass custom importer which turns ~ into absolute paths to the nearest parent node_modules directory.",
   "repository": "matthewdavidson/node-sass-tilde-importer",
   "main": "index.js",
@@ -30,6 +30,7 @@
   "jest": {
     "verbose": true,
     "testRegex": "test\\.js$",
+    "testEnvironment": "node",
     "coverageThreshold": {
       "global": {
         "statements": 75,

--- a/test.js
+++ b/test.js
@@ -10,15 +10,34 @@ beforeEach(function() {
   findParentDir.sync.mockReturnValue('test');
 });
 
-test('resolves to node_modules directory when first character is ~', function () {
+test('resolves to node_modules directory when first character is ~', function() {
   expect(importer('~my-module', '')).toEqual({ file: __dirname + '/test/node_modules/my-module' });
 });
 
-test('does nothing when the first character isnt a ~', function () {
+test('does nothing when the first character isnt a ~', function() {
   expect(importer('my-module', '')).toEqual({ file: 'my-module' });
 });
 
-test('fallback to flat resolve if deep failed', function() {
-  fs.existsSync.mockReturnValue(false);
-  expect(importer('~my-module', '')).toEqual({ file: __dirname + '/node_modules/my-module' });
+test('recursively resolve url until package has not been found', function() {
+  var mockFsCheck = fs.existsSync,
+      mockParentDirFinder = findParentDir.sync;
+
+  // url can not be resolved up to 10 level
+  for (var i = 0; i < 10; i++) {
+    mockFsCheck = mockFsCheck.mockReturnValueOnce(false);
+    mockParentDirFinder = mockParentDirFinder.mockReturnValueOnce('test' + i);
+  }
+
+  // url finally found
+  mockFsCheck.mockReturnValueOnce(true);
+  mockParentDirFinder.mockReturnValueOnce('final');
+
+  expect(importer('~my-module', '')).toEqual({ file: __dirname + '/final/node_modules/my-module' });
+});
+
+test('return null when package file can not be resolved', function() {
+  fs.existsSync.mockReturnValue(false)
+  findParentDir.sync.mockReturnValue(null);
+
+  expect(importer('~my-module', '')).toBeNull();
 });

--- a/test.js
+++ b/test.js
@@ -1,13 +1,24 @@
+jest.mock("fs");
+jest.mock("find-parent-dir");
+
 var importer = require('./index');
+var fs = require('fs');
+var findParentDir = require('find-parent-dir');
+
+beforeEach(function() {
+  fs.existsSync.mockReturnValue(true);
+  findParentDir.sync.mockReturnValue('test');
+});
 
 test('resolves to node_modules directory when first character is ~', function () {
-  expect(importer('~my-module', '')).toEqual({
-    file: __dirname + '/node_modules/my-module'
-  });
+  expect(importer('~my-module', '')).toEqual({ file: __dirname + '/test/node_modules/my-module' });
 });
 
 test('does nothing when the first character isnt a ~', function () {
-  expect(importer('my-module', '')).toEqual({
-    file: 'my-module'
-  });
+  expect(importer('my-module', '')).toEqual({ file: 'my-module' });
+});
+
+test('fallback to flat resolve if deep failed', function() {
+  fs.existsSync.mockReturnValue(false);
+  expect(importer('~my-module', '')).toEqual({ file: __dirname + '/node_modules/my-module' });
 });

--- a/test.js
+++ b/test.js
@@ -6,12 +6,17 @@ var fs = require('fs');
 var findParentDir = require('find-parent-dir');
 
 beforeEach(function() {
+  fs.existsSync.mockClear();
   fs.existsSync.mockReturnValue(true);
-  findParentDir.sync.mockReturnValue('test');
+
+  findParentDir.sync.mockClear();
+  findParentDir.sync.mockReturnValue('MOCK_PARENT_DIR');
 });
 
 test('resolves to node_modules directory when first character is ~', function() {
-  expect(importer('~my-module', '')).toEqual({ file: __dirname + '/test/node_modules/my-module' });
+  expect(importer('~my-module', '')).toEqual({
+     file: __dirname + '/MOCK_PARENT_DIR/node_modules/my-module'
+  });
 });
 
 test('does nothing when the first character isnt a ~', function() {
@@ -25,19 +30,24 @@ test('recursively resolve url until package has not been found', function() {
   // url can not be resolved up to 10 level
   for (var i = 0; i < 10; i++) {
     mockFsCheck = mockFsCheck.mockReturnValueOnce(false);
-    mockParentDirFinder = mockParentDirFinder.mockReturnValueOnce('test' + i);
+    mockParentDirFinder = mockParentDirFinder.mockReturnValueOnce('MOCK_PARENT_DIR' + i);
   }
 
   // url finally found
-  mockFsCheck.mockReturnValueOnce(true);
-  mockParentDirFinder.mockReturnValueOnce('final');
+  mockFsCheck = mockFsCheck.mockReturnValueOnce(true);
+  mockParentDirFinder = mockParentDirFinder.mockReturnValueOnce('MOCK_PARENT_DIR_final');
 
-  expect(importer('~my-module', '')).toEqual({ file: __dirname + '/final/node_modules/my-module' });
+  expect(importer('~my-module', '')).toEqual({
+    file: __dirname + '/MOCK_PARENT_DIR_final/node_modules/my-module'
+  });
+
+  expect(mockParentDirFinder.mock.calls.length).toBe(11);
+  expect(mockFsCheck.mock.calls.length).toBe(11);
 });
 
 test('return null when package file can not be resolved', function() {
   fs.existsSync.mockReturnValue(false)
   findParentDir.sync.mockReturnValue(null);
 
-  expect(importer('~my-module', '')).toBeNull();
+  expect(importer('~my-module', '')).toEqual({ file: null });
 });


### PR DESCRIPTION
This change is meant to address that scenario when you have conflicting versions of dependencies. In that case npm 3 would still install it nested while also have it in the top level node_module. My change tries to resolve the deep dependency (nested one) and then does a fallback to flat.