### PR TITLE
Append scss extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function resolve(targetUrl, source) {
   var isPotentiallyDirectory = !path.extname(filePath);
 
   if (isPotentiallyDirectory) {
-    if (s.existsSync(filePath + '.scss')) {
+    if (fs.existsSync(filePath + '.scss')) {
       return path.resolve(filePath, 'index');
     }
 

--- a/index.js
+++ b/index.js
@@ -12,9 +12,17 @@ function resolve(targetUrl, source) {
   var filePath = path.resolve(packageRoot, 'node_modules', targetUrl);
   var isPotentiallyDirectory = !path.extname(filePath);
 
-  if (isPotentiallyDirectory && fs.existsSync(filePath)) {
-    return path.resolve(filePath, 'index');
-  } else if (fs.existsSync(path.dirname(filePath))) {
+  if (isPotentiallyDirectory) {
+    if (s.existsSync(filePath + '.scss')) {
+      return path.resolve(filePath, 'index');
+    }
+
+    if (fs.existsSync(filePath)) {
+      return path.resolve(filePath, 'index');
+    }
+  }
+
+  if (fs.existsSync(path.dirname(filePath))) {
     return filePath;
   }
 

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function resolve(targetUrl, source) {
 
   if (isPotentiallyDirectory) {
     if (fs.existsSync(filePath + '.scss')) {
-      return path.resolve(filePath, 'index');
+      return filePath + '.scss';
     }
 
     if (fs.existsSync(filePath)) {

--- a/index.test.js
+++ b/index.test.js
@@ -77,4 +77,13 @@ describe('Importer', function() {
       file: __dirname + '/MOCK_PARENT_DIR/node_modules/my-module/test/index'
     });
   });
+
+  test('should support directory imports', function() {
+    mockFs.existsSync.mockReturnValueOnce(true); // directory import
+    mockFs.writeFileSync(__dirname + '/MOCK_PARENT_DIR/node_modules/my-module/test.scss', 'body { color: red; }');
+
+    expect(importer('~my-module/test', '')).toEqual({
+      file: __dirname + '/MOCK_PARENT_DIR/node_modules/my-module/test.scss'
+    });
+  });
 });

--- a/index.test.js
+++ b/index.test.js
@@ -12,7 +12,7 @@ describe('Importer', function() {
   });
 
   test('resolves to node_modules directory when first character is ~', function() {
-    mockFs.existsSync.mockReturnValue(true);
+    mockFs.existsSync.mockReturnValueOnce(false).mockReturnValue(true);
     expect(importer('~my-module', '')).toEqual({
       file: __dirname + '/MOCK_PARENT_DIR/node_modules/my-module/index'
     });
@@ -29,6 +29,7 @@ describe('Importer', function() {
     // url can not be resolved up to 10 level
     for (var i = 0; i < 10; i++) {
       mockFsCheck = mockFsCheck
+        .mockReturnValueOnce(false) // .scss import
         .mockReturnValueOnce(false) // directory import
         .mockReturnValueOnce(false); // file import
 
@@ -36,7 +37,10 @@ describe('Importer', function() {
     }
 
     // url finally found
-    mockFsCheck = mockFsCheck.mockReturnValueOnce(false).mockReturnValueOnce(true);
+    mockFsCheck = mockFsCheck
+      .mockReturnValueOnce(false) // .scss import
+      .mockReturnValueOnce(false) // directory import
+      .mockReturnValueOnce(true); // file import
     mockParentDirFinder = mockParentDirFinder.mockReturnValueOnce('MOCK_PARENT_DIR_final');
 
     expect(importer('~my-module/test', '')).toEqual({
@@ -44,16 +48,19 @@ describe('Importer', function() {
     });
 
     expect(mockParentDirFinder.mock.calls.length).toBe(11);
-    expect(mockFsCheck.mock.calls.length).toBe(22);
+    expect(mockFsCheck.mock.calls.length).toBe(33);
   });
 
   test('return null when package file can not be resolved', function() {
+    mockFs.existsSync.mockReturnValue(false);
     mockFindParentDir.sync.mockReturnValue(null);
     expect(importer('~my-module', '')).toEqual({ file: null });
   });
 
   test('should resolve extensions', function() {
-    mockFs.existsSync.mockReturnValueOnce(true);
+    mockFs.existsSync
+      .mockReturnValueOnce(false) // .scss import
+      .mockReturnValueOnce(true); // directory import
 
     expect(importer('~my-module/test.scss', '')).toEqual({
       file: __dirname + '/MOCK_PARENT_DIR/node_modules/my-module/test.scss'
@@ -62,6 +69,7 @@ describe('Importer', function() {
 
   test('should support file imports', function() {
     mockFs.existsSync
+      .mockReturnValueOnce(false) // .scss import
       .mockReturnValueOnce(false) // directory import
       .mockReturnValueOnce(true); // file import
 
@@ -71,16 +79,17 @@ describe('Importer', function() {
   });
 
   test('should support directory imports', function() {
-    mockFs.existsSync.mockReturnValueOnce(true); // directory import
+    mockFs.existsSync
+      .mockReturnValueOnce(false) // .scss import
+      .mockReturnValueOnce(true); // directory import
 
     expect(importer('~my-module/test', '')).toEqual({
       file: __dirname + '/MOCK_PARENT_DIR/node_modules/my-module/test/index'
     });
   });
 
-  test('should support directory imports', function() {
-    mockFs.existsSync.mockReturnValueOnce(true); // directory import
-    mockFs.writeFileSync(__dirname + '/MOCK_PARENT_DIR/node_modules/my-module/test.scss', 'body { color: red; }');
+  test('should support file imports minus extension', function() {
+    mockFs.existsSync.mockReturnValueOnce(true); // .scss import
 
     expect(importer('~my-module/test', '')).toEqual({
       file: __dirname + '/MOCK_PARENT_DIR/node_modules/my-module/test.scss'


### PR DESCRIPTION
Hi,

Here is what I had to do to be able to import scss files using a syntax like `~module-name/file` omitting `.scss` (for consistency with our other imports).

Thanks,