### PR TITLE
add bin command to be resolved in a subproject with yarn workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "A node-sass custom importer which turns ~ into absolute paths to the nearest parent node_modules directory.",
   "repository": "matthewdavidson/node-sass-tilde-importer",
   "main": "index.js",
+  "bin" : {
+    "node-sass-tilde-importer" : "./index.js"
+  },
   "scripts": {
     "test": "jest --coverage"
   },


### PR DESCRIPTION
Hey there, it might be helpful for some of us to have a reference of the package in the `node_modules` folder

example usage:

```
"css:build": "$(yarn bin)/node-sass --importer=$(yarn bin)/node-sass-tilde-importer ./src/scss/styles.scss ./lib/styles.css",
```

instead of:

```
"css:build": "$(yarn bin)/node-sass --importer=./../node_modules/node-sass-tilde-importer ./src/scss/styles.scss ./lib/styles.css",
```